### PR TITLE
[GHI #36] Add ability to disable dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If your application does not use or need dark mode, it can be disabled by adding
 
 ```html
 <!DOCTYPE html>
-<html data-dark-mode='false'>
+<html data-allow-dark-mode-preference='false'>
   ...
 </html>
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ If you do not want all the styles RoleModel Design System provides, you can impo
 @import '@rolemodel/rolemodel-design-system/scss/components/button.scss';
 ```
 
-## Component Documentation
+## Documentation
+
+### Dark Mode
+
+Dark mode is enabled by default and will dynamically flip your semantic tokens to a dark version of it based on your system setting.
+If your application does not use or need dark mode, it can be disabled by adding a data attribute to your root `html` tag.
+
+```html
+<!DOCTYPE html>
+<html data-dark-mode='false'>
+  ...
+</html>
+```
+
+### Components
 
 [Buttons](./docs/components/button/button.md)

--- a/src/core/tokens/dark_mode_tokens.scss
+++ b/src/core/tokens/dark_mode_tokens.scss
@@ -69,7 +69,7 @@
   }
 }
 
-:root:not([data-dark-mode='false']) {
+:root:not([data-allow-dark-mode-preference='false']) {
   @media (prefers-color-scheme: dark) {
     & {
       // Semantic Scales: plus adds luminosity, minus removes luminosity

--- a/src/core/tokens/dark_mode_tokens.scss
+++ b/src/core/tokens/dark_mode_tokens.scss
@@ -69,7 +69,7 @@
   }
 }
 
-:root {
+:root:not([data-dark-mode='false']) {
   @media (prefers-color-scheme: dark) {
     & {
       // Semantic Scales: plus adds luminosity, minus removes luminosity

--- a/src/theme/rolemodel_theme.scss
+++ b/src/theme/rolemodel_theme.scss
@@ -123,7 +123,7 @@
   @include neutral-semantic-scale;
 }
 
-:root:not([data-dark-mode='false']) {
+:root:not([data-allow-dark-mode-preference='false']) {
   @media (prefers-color-scheme: dark) {
     & {
       @include primary-semantic-scale-dark;

--- a/src/theme/rolemodel_theme.scss
+++ b/src/theme/rolemodel_theme.scss
@@ -121,7 +121,9 @@
 
   @include primary-semantic-scale;
   @include neutral-semantic-scale;
+}
 
+:root:not([data-dark-mode='false']) {
   @media (prefers-color-scheme: dark) {
     & {
       @include primary-semantic-scale-dark;


### PR DESCRIPTION
## Task

#36 

## Why?

This addresses a part of the above-mentioned issue. In applications that do not have a dark mode, or need to temporarily disable it, there is no easy way to do that.

The current solution is to selectively import everything the `rolemodel-design-system.scss` file imports and then remove the one line that imports the dark mode tokens.

This solution allows an application to disable dark mode by setting a data attribute on the `html` element.

## What Changed

* [X] Add ability to disable dark mode via a data attribute
* [X] Add documentation explaining dark mode and how to disable it
