### PR TITLE
Specify scss for material symbols import

### DIFF
--- a/src/components/icon.scss
+++ b/src/components/icon.scss
@@ -1,7 +1,7 @@
 // Look up icons at: https: //fonts.google.com/icons?icon.set=Material+Symbols
 // https://github.com/marella/material-symbols/tree/main/material-symbols#readme
 $material-symbols-font-path: '~material-symbols/';
-@import 'material-symbols/outlined';
+@import 'material-symbols/outlined.scss';
 
 .material-symbols-outlined,
 .material-symbols {


### PR DESCRIPTION
## Why?

If an application uses a compiler other than webpack. I.E. Dart Sass, when it gets to the material symbols import, it isn't smart enough to know to pull the .scss version of material symbols so we need to be explicit about it

## What Changed

* [X] Change material symbol import to specify `.scss`

## Sanity Check

* [X] Have you updated any usage of changed tokens?
* [X] Have you updated the `docs/token_structure.json` file?
* [X] Have you updated the docs with any component changes?
* [X] Do you need to update the package version?
