### PR TITLE
Material Symbols Update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@rolemodel/rolemodel-design-system",
-  "version": "0.0.5-beta",
+  "version": "0.0.6-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rolemodel/rolemodel-design-system",
-      "version": "0.0.5-beta",
+      "version": "0.0.6-beta",
       "license": "MIT",
       "dependencies": {
-        "material-symbols": "^0.1.0",
         "modern-css-reset": "^1.4.0",
         "tom-select": "^2.0.0"
       },
@@ -168,11 +167,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/material-symbols": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.1.0.tgz",
-      "integrity": "sha512-iL9+NDHYe6XTSH7YfTSMUM/r1/aPGXT0jqBRgx0OzjwQ9yvQ6iuid42mzcBINlGEIWDmmDFh4lYwg4rEKOlWnQ=="
     },
     "node_modules/modern-css-reset": {
       "version": "1.4.0",
@@ -373,11 +367,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "material-symbols": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.1.0.tgz",
-      "integrity": "sha512-iL9+NDHYe6XTSH7YfTSMUM/r1/aPGXT0jqBRgx0OzjwQ9yvQ6iuid42mzcBINlGEIWDmmDFh4lYwg4rEKOlWnQ=="
     },
     "modern-css-reset": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolemodel/rolemodel-design-system",
-  "version": "0.0.5-beta",
+  "version": "0.0.6-beta",
   "description": "The design system RoleModel uses to kickstart projects with a consistent starting point",
   "main": "dist/scss/rolemodel-design-system.scss",
   "scripts": {
@@ -31,7 +31,6 @@
     "@RoleModel:registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
-    "material-symbols": "^0.1.0",
     "modern-css-reset": "^1.4.0",
     "tom-select": "^2.0.0"
   },

--- a/src/components/icon.scss
+++ b/src/components/icon.scss
@@ -1,7 +1,9 @@
-// Look up icons at: https: //fonts.google.com/icons?icon.set=Material+Symbols
-// https://github.com/marella/material-symbols/tree/main/material-symbols#readme
-$material-symbols-font-path: '~material-symbols/';
-@import 'material-symbols/outlined.scss';
+// Look up icons at: https://fonts.google.com/icons?icon.set=Material+Symbols
+// Instead of hosting the font files locally which requires the compiler to handle them, we pull the icons
+// from Googles CDN like we do for our other fonts
+// https://developers.google.com/fonts/docs/material_symbols#variable_font_with_google_fonts
+
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200');
 
 .material-symbols-outlined,
 .material-symbols {


### PR DESCRIPTION
## Why?

Once again... When you are not in a webpack compiling context, using a local version of the material symbols icons was not compiling properly.

## What Changed

* [X] Pull Material Symbols Icons from cdn instead of using a local npm package.
* [X] Remove npm package dependency

## Sanity Check

* [X] Have you updated any usage of changed tokens?
* [X] Have you updated the `docs/token_structure.json` file?
* [X] Have you updated the docs with any component changes?
* [X] Do you need to update the package version?
