### PR TITLE
fix formatting for exported json

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,6 @@ What changed in this PR?
 ## Sanity Check
 
 * [ ] Have you updated any usage of changed tokens?
-* [ ] Have you updated the `docs/token_structure.json` file?
 * [ ] Have you updated the docs with any component changes?
 * [ ] Do you need to update the package version?
 

--- a/build_token_json.js
+++ b/build_token_json.js
@@ -81,7 +81,7 @@ try {
         variables = addToJson(splitKey(key.trim()), variables, value.trim())
       })
     })
-    fs.writeFileSync(`${outputPath}/${outputFile}`, JSON.stringify(variables))
+    fs.writeFileSync(`${outputPath}/${outputFile}`, JSON.stringify(variables, null, '\t'))
   })
 
 } catch(err) {


### PR DESCRIPTION
## Why?
The JSON formatting for exported tokens was very difficult to read

## What Changed

What changed in this PR?

* [x] Update formatting for exported tokens to be much easier to read
## Sanity Check

* [x] Have you updated any usage of changed tokens?
* [x] Have you updated the `docs/token_structure.json` file?
* [x] Have you updated the docs with any component changes?
* [x] Do you need to update the package version?