### PR TITLE
[GHI #61] Button Icon with Size

### DIFF
--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -1,4 +1,6 @@
 %btn {
+  --rm-button-height: var(--rm-input-height-medium);
+
   -webkit-appearance: none;
   display: inline-grid;
   grid-auto-flow: column;
@@ -14,7 +16,7 @@
 
   padding: 0 var(--rm-space-medium);
 
-  height: var(--rm-input-height-medium);
+  height: var(--rm-button-height);
 
   cursor: pointer;
 
@@ -173,19 +175,19 @@
 
 // Small Size Modifier
 .btn--small {
-  height: var(--rm-input-height-small);
+  --rm-button-height: var(--rm-input-height-small);
   font-size: var(--rm-font-x-small);
 }
 
 // Medium Size (default size) Modifier
 .btn--medium {
-  height: var(--rm-input-height-medium);
+  --rm-button-height: var(--rm-input-height-medium);
   font-size: var(--rm-font-small);
 }
 
 // Large Size Modifier
 .btn--large {
-  height: var(--rm-input-height-large);
+  --rm-button-height: var(--rm-input-height-large);
   font-size: var(--rm-font-medium);
 }
 
@@ -195,17 +197,6 @@
 
   border-radius: var(--rm-radius-circle);
 
-  width: var(--rm-input-height-medium);
-}
-
-.btn--icon.btn--small {
-  width: var(--rm-input-height-small);
-}
-
-.btn--icon.btn--medium {
-  width: var(--rm-input-height-medium);
-}
-
-.btn--icon.btn--large {
-  width: var(--rm-input-height-large);
+  height: var(--rm-button-height);
+  width: var(--rm-button-height);
 }

--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -171,15 +171,6 @@
   border-radius: var(--rm-radius-pill);
 }
 
-// Icon Shape Modifier
-.btn--icon {
-  padding: 0;
-
-  border-radius: var(--rm-radius-circle);
-
-  width: var(--rm-input-height-medium);
-}
-
 // Small Size Modifier
 .btn--small {
   height: var(--rm-input-height-small);
@@ -196,4 +187,25 @@
 .btn--large {
   height: var(--rm-input-height-large);
   font-size: var(--rm-font-medium);
+}
+
+// Icon Shape Modifier
+.btn--icon {
+  padding: 0;
+
+  border-radius: var(--rm-radius-circle);
+
+  width: var(--rm-input-height-medium);
+}
+
+.btn--icon.btn--small {
+  width: var(--rm-input-height-small);
+}
+
+.btn--icon.btn--medium {
+  width: var(--rm-input-height-medium);
+}
+
+.btn--icon.btn--large {
+  width: var(--rm-input-height-large);
 }


### PR DESCRIPTION
## Task

https://github.com/RoleModel/rolemodel-design-system/issues/61

## What Changed

* [X] Set widths of buttons properly when `.btn--icon` when used with `.btn--small`, `.btn--medium`, and `.btn--large`

## Sanity Check

* ~~Have you updated any usage of changed tokens?~~
* ~~Have you updated the docs with any component changes?~~
* ~~Do you need to update the package version?~~

## Screenshots

<img width="123" alt="Screen Shot 2022-08-21 at 4 02 26 PM" src="https://user-images.githubusercontent.com/5957102/185808838-2763beb2-879e-41a6-9459-23b3244e87ee.png">
<img width="116" alt="Screen Shot 2022-08-21 at 4 02 30 PM" src="https://user-images.githubusercontent.com/5957102/185808840-f614f0bc-f586-4a11-9023-149d96f41799.png">
<img width="95" alt="Screen Shot 2022-08-21 at 4 02 34 PM" src="https://user-images.githubusercontent.com/5957102/185808841-2ab9aa5f-94fe-446d-b017-1c079922d705.png">
