### PR TITLE
[GHI #72] button icon with breakpoints

### DIFF
--- a/src/components/button.scss
+++ b/src/components/button.scss
@@ -151,6 +151,17 @@
     --__rm-btn-font-size: var(--_rm-font-large);
   }
 
+  // https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/
+  @media(max-width: $breakpoint-small) {
+    --__rm-btn-height: var(--_rm-btn-height-large);
+    --__rm-btn-font-size: var(--_rm-font-large);
+
+    &.btn--small, &.btn--medium, &.btn--large {
+      --__rm-btn-height: var(--_rm-btn-height-large);
+      --__rm-btn-font-size: var(--_rm-font-large);
+    }
+  }
+
   // Disabled Modifier
   &.btn--disabled,
   &:disabled {

--- a/src/stories/Button/Button.mdx
+++ b/src/stories/Button/Button.mdx
@@ -87,6 +87,13 @@ Button classes can be used on `button` or `a` html elements. They provide consis
   <Story id='components-button--size' />
 </Canvas>
 
+## Mobile Buttons
+
+All button classes, regardless of the currently applied size modifier, will automatically adjust to the large button size on mobile screens ($breakpoint-small ~ 768px).
+This is to ensure a large enough tap area on smaller devices and screens.
+
+See https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/
+
 ## Button API
 
 The button styles are built on css variables scoped to the button.

--- a/src/stories/Button/Button.mdx
+++ b/src/stories/Button/Button.mdx
@@ -99,49 +99,49 @@ See https://uxmovement.com/mobile/optimal-size-and-spacing-for-mobile-buttons/
 The button styles are built on css variables scoped to the button.
 
 Here is the full public API that the button uses.
-```scss
+```css
 // Normal
---_rm-btn-background-color
---_rm-btn-text-color
---_rm-btn-border-color
+--_rm-btn-background-color:
+--_rm-btn-text-color:
+--_rm-btn-border-color:
 
 // Hover
---_rm-btn-background-hover-color
---_rm-btn-text-hover-color
---_rm-btn-border-hover-color
+--_rm-btn-background-hover-color:
+--_rm-btn-text-hover-color:
+--_rm-btn-border-hover-color:
 
 // Outline
---_rm-btn-background-outline-color
---_rm-btn-text-outline-color
---_rm-btn-border-outline-color
+--_rm-btn-background-outline-color:
+--_rm-btn-text-outline-color:
+--_rm-btn-border-outline-color:
 
 // Hover and Outline
---_rm-btn-background-hover-and-outline-color
---_rm-btn-text-hover-and-outline-color
---_rm-btn-border-hover-and-outline-color
+--_rm-btn-background-hover-and-outline-color:
+--_rm-btn-text-hover-and-outline-color:
+--_rm-btn-border-hover-and-outline-color:
 
 // No Border
---_rm-btn-background-no-border-color
---_rm-btn-text-no-border-color
+--_rm-btn-background-no-border-color:
+--_rm-btn-text-no-border-color:
 
 // Hover and no Border
---_rm-btn-background-hover-and-no-border-color
---_rm-btn-text-hover-and-no-border-color
+--_rm-btn-background-hover-and-no-border-color:
+--_rm-btn-text-hover-and-no-border-color:
 
 // General Properties (for size and height, the appropriate variable is used when using the size modifiers)
---_rm-btn-font-weight
---_rm-btn-gap
---_rm-btn-transition
---_rm-btn-padding
---_rm-btn-radius
+--_rm-btn-font-weight:
+--_rm-btn-gap:
+--_rm-btn-transition:
+--_rm-btn-padding:
+--_rm-btn-radius:
 
---_rm-btn-height-small
---_rm-btn-height-medium
---_rm-btn-height-large
+--_rm-btn-height-small:
+--_rm-btn-height-medium:
+--_rm-btn-height-large:
 
---_rm-font-small
---_rm-font-medium
---_rm-font-large
+--_rm-font-small:
+--_rm-font-medium:
+--_rm-font-large:
 ```
 
 ## Overriding Button styles
@@ -149,14 +149,14 @@ Here is the full public API that the button uses.
 The button classes are built on a sass placeholder selector https://sass-lang.com/documentation/style-rules/placeholder-selectors
 
 This allows multiple button classes to share the same behavior. You can modify all buttons behavior by overriding the `%btn-global` placeholder selector and setting any of the **general properties** documented tokens:
-```scss
+```css
 %btn-global {
   --_rm-btn-radius: var(--rm-radius-x-large);
 }
 ```
 
 If you need to override the color of a particular button style, you can open the respective class and change the **non-general properties** documented above
-```scss
+```css
 // This will only affect the default button, but not primary, secondary, etc.
 .btn {
   --_rm-btn-background-color: red;
@@ -172,7 +172,7 @@ Your application may need a custom button. To add one:
 2. Extend `%btn-global`
 3. Use the above documented API to define how it looks and feels for different states (e.g. hover, outline)
 
-```scss
+```css
 .btn-redsky {
   @extend %btn-global;
 


### PR DESCRIPTION
## Task

https://github.com/RoleModel/rolemodel-design-system/issues/72

## Why?

Not only was the initial implementation of the small breakpoint size adjustment not handling `btn--icon` correctly,
It was accidentally removed in https://github.com/RoleModel/rolemodel-design-system/pull/80/files

This PR adds it back and fixes previous bugs

## What Changed

* [X] Add small breakpoint override of button size
* [X] Update the button docs to highlight scss

## Sanity Check

* ~~Have you updated any usage of changed tokens?~~
* [X] Have you updated the docs with any component changes?
* ~~Do you need to update the package version?~~

## Screenshots

![Screen Shot 2022-09-14 at 4 16 23 PM](https://user-images.githubusercontent.com/5957102/190253606-d50ced55-9e31-464c-bc27-32115d55fd53.png)

![Screen Shot 2022-09-14 at 4 16 16 PM](https://user-images.githubusercontent.com/5957102/190253656-372d8ca6-a090-49a1-8f4f-9bfa96583413.png)
