### PR TITLE
[GHI #40] Form Group and error messages

### DIFF
--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -179,10 +179,10 @@
 
 // simple_form error styles
 .form__error-summary {
-  background-color: var(--rm-color-alerts-danger-plus-2);
-  color: var(--rm-color-alerts-danger-on-plus-2);
+  background-color: var(--rm-color-alerts-danger-plus-3);
+  color: var(--rm-color-alerts-danger-on-plus-3);
 
-  box-shadow: var(--rm-border-all) var(--rm-color-alerts-danger-plus-1);
+  box-shadow: var(--rm-border-all) var(--rm-color-alerts-danger-on-plus-3);
   border-radius: var(--rm-radius-large);
 
   padding: var(--rm-space-large);
@@ -204,8 +204,8 @@
   padding: var(--rm-space-2x-small) var(--rm-space-x-small);
   width: fit-content;
 
-  background: var(--rm-color-alerts-danger-plus-2);
-  color: var(--rm-color-alerts-danger-on-plus-2);
+  background: var(--rm-color-alerts-danger-plus-3);
+  color: var(--rm-color-alerts-danger-on-plus-3);
 
   border-radius: var(--rm-radius-medium);
 

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -199,8 +199,6 @@
 }
 
 .form__error {
-  display: block;
-
   padding: var(--rm-space-2x-small) var(--rm-space-x-small);
   width: fit-content;
 

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -1,12 +1,33 @@
 // Input Group
-// Future Idea: Can we use gap here instead of padding on the label and hint?
 .form__group {
   padding: var(--rm-space-small) 0;
+
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-auto-rows: auto;
+  gap: var(--rm-space-x-small);
+}
+
+.form__label,
+.form__input,
+.form__error,
+.form__hint {
+  grid-column: 1 / 3;
+}
+
+.form__checkbox,
+.form__radio {
+  grid-column: 1 / 1;
+  align-self: center;
+
+  & + .form__label {
+    grid-column: 2 / 3;
+    grid-row: 1;
+  }
 }
 
 // Label
 .form__label {
-  padding-bottom: var(--rm-space-x-small);
   color: var(--rm-color-on-background);
   font-weight: var(--rm-font-weight-normal);
   font-size: var(--rm-font-small);
@@ -95,7 +116,6 @@
   border-radius: var(--rm-radius-circle);
 
   vertical-align: middle;
-  margin-right: var(--rm-space-x-small);
 
   cursor: pointer;
 
@@ -182,7 +202,6 @@
   display: block;
 
   padding: var(--rm-space-2x-small) var(--rm-space-x-small);
-  margin-top: var(--rm-space-x-small); // Is there a future solution with gap possible here?
   width: fit-content;
 
   background: var(--rm-color-alerts-danger-plus-2);
@@ -201,7 +220,6 @@
 
 .form__hint {
   display: block;
-  padding-top: var(--rm-space-x-small);
   font-size: var(--rm-font-small);
   font-style: italic;
 }

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -185,10 +185,11 @@
 }
 
 .form__error {
-  display: inline-block;
+  display: block;
 
   padding: var(--rm-space-2x-small) var(--rm-space-x-small);
-  margin-left: var(--rm-space-x-small); // Is there a future solution with gap possible here?
+  margin-top: var(--rm-space-x-small); // Is there a future solution with gap possible here?
+  width: fit-content;
 
   background: var(--rm-color-alerts-danger-plus-2);
   color: var(--rm-color-alerts-danger-on-plus-2);

--- a/src/components/form.scss
+++ b/src/components/form.scss
@@ -4,12 +4,6 @@
   padding: var(--rm-space-small) 0;
 }
 
-.form__inline-group {
-  display: flex;
-  align-items: center;
-  gap: var(--rm-space-small);
-}
-
 // Label
 .form__label {
   padding-bottom: var(--rm-space-x-small);

--- a/src/stories/Form/Form.js
+++ b/src/stories/Form/Form.js
@@ -118,13 +118,9 @@ export const createErrorSummary = ({ label }) => {
   return element;
 };
 
-export const createFormGroup = ({ label, type, error, inline, hint, readonly }) => {
+export const createFormGroup = ({ label, type, error, hint, readonly }) => {
   const element = document.createElement('div');
   element.className = 'form__group';
-
-  if (inline) {
-    element.className += ' form__inline-group';
-  }
 
   if (error) {
     element.className += ' form__input--error';

--- a/src/stories/Form/Form.js
+++ b/src/stories/Form/Form.js
@@ -136,12 +136,12 @@ export const createFormGroup = ({ label, type, error, inline, hint, readonly }) 
 
   if (type == 'checkbox' || type == 'radio') {
     element.appendChild(createInput({ type, readonly }))
-    if (error) { element.appendChild(errorElement) }
     element.appendChild(createLabel({ label }))
+    if (error) { element.appendChild(errorElement) }
   } else {
     element.appendChild(createLabel({ label }))
-    if (error) { element.appendChild(errorElement) }
     element.appendChild(createInput({ type, readonly }))
+    if (error) { element.appendChild(errorElement) }
   }
 
   if (hint) {

--- a/src/stories/Form/Form.mdx
+++ b/src/stories/Form/Form.mdx
@@ -32,14 +32,6 @@ They provide consistent and composable styling that should address most applicat
   <Story id='components-form-formgroup--default' />
 </Canvas>
 
-## Form Inline Group
-
-`.form__inline-group` Composes an input and label together as a side by side pair. It can be used with `form__group` to get padding as well as side by side label and input.
-
-<Canvas withToolbar>
-  <Story id='components-form-formgroup--inline' />
-</Canvas>
-
 ## Textarea
 
 `.form__textarea` Provides basic text area styles. This can be used on `textarea` html elements.

--- a/src/stories/FormGroup.stories.js
+++ b/src/stories/FormGroup.stories.js
@@ -14,9 +14,6 @@ export default {
     error: {
       control: { type: 'text' },
     },
-    inline: {
-      control: { type: 'boolean' },
-    },
     hint: {
       control: { type: 'text' },
     }
@@ -38,14 +35,6 @@ export const Default = Template.bind({});
 Default.args = {
   ...LabelStories.Default.args,
   ...InputStories.Default.args,
-};
-
-export const Inline = Template.bind({});
-// More on args: https://storybook.js.org/docs/html/writing-stories/args
-Inline.args = {
-  ...LabelStories.Default.args,
-  ...InputStories.Default.args,
-  inline: true
 };
 
 export const Radio = Template.bind({});


### PR DESCRIPTION
## Task

https://github.com/RoleModel/rolemodel-design-system/issues/40

## Why?

Error messages don't wrap cleanly. Additionally, form group didn't take advantage of gap which required using padding or margin on the inner elements which led to occasional inconsistent spacing.

## What Changed

* [X] Update form group to use gap and grid
* [X] Remove spacing from label, checkbox, hint, and error
* [X] Move error to below label.
* [X] Update color of error message and error summary to be more subtle.
* [X] Remove form inline group as it was not used

## Sanity Check

* ~~Have you updated any usage of changed tokens?~~
* ~~Have you updated the docs with any component changes?~~
* ~~Do you need to update the package version?~~

## Screenshots

<img width="658" alt="Screen Shot 2022-09-17 at 2 39 27 PM" src="https://user-images.githubusercontent.com/5957102/190871951-35e8dd0b-628c-4a91-8a4c-66a9894bf77b.png">
<img width="663" alt="Screen Shot 2022-09-17 at 2 39 33 PM" src="https://user-images.githubusercontent.com/5957102/190871952-255ca95e-09b1-4930-b333-014bc1a33e5e.png">
