### PR TITLE
[GHI #82] Table Enhancements

### DIFF
--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -79,6 +79,51 @@
   tfoot tr {
     box-shadow: var(--_rm-table-foot-border);
   }
+
+  // Layout Modifiers
+  &.table--auto-layout { --_rm-table-layout: auto; }
+  &.table--fixed-layout { --_rm-table-layout: fixed; }
+
+  // Table Density Modifiers
+  &.table--default-density {
+    --_rm-table-cell-padding: var(--_rm-table-cell-padding-default);
+  }
+
+  &.table--comfortable-density {
+    --_rm-table-cell-padding: var(--_rm-table-cell-padding-comfortable);
+  }
+
+  &.table--compact-density {
+    --_rm-table-cell-padding: var(--_rm-table-cell-padding-compact);
+  }
+
+  // Striped Modifiers
+  &.table--even-striped {
+    tbody tr:nth-child(even) {
+      background-color: var(--_rm-table-striping-background-color);
+      color: var(--_rm-table-striping-text-color);
+    }
+  }
+
+  &.table--odd-striped {
+    tbody tr:nth-child(odd) {
+      background-color: var(--_rm-table-striping-background-color);
+      color: var(--_rm-table-striping-text-color);
+    }
+  }
+
+  // Sticky Header Row Modifier
+  &.table--sticky-header thead {
+    position: sticky;
+    top: 0;
+  }
+
+  // Sticky Footer Row Modifier
+  &.table--sticky-footer tfoot {
+    position: sticky;
+    bottom: 0;
+    background-color: var(--_rm-table-background-color);
+  }
 }
 
 // Default Table
@@ -102,38 +147,6 @@
   --_rm-table-head-text-color: var(--rm-color-alerts-danger-oy-plus-3);
 }
 
-// Layout Modifiers
-.table--auto-layout { --_rm-table-layout: auto; }
-.table--fixed-layout { --_rm-table-layout: fixed; }
-
-// Table Density Modifiers
-.table--default-density {
-  --_rm-table-cell-padding: var(--_rm-table-cell-padding-default);
-}
-
-.table--comfortable-density {
-  --_rm-table-cell-padding: var(--_rm-table-cell-padding-comfortable);
-}
-
-.table--compact-density {
-  --_rm-table-cell-padding: var(--_rm-table-cell-padding-compact);
-}
-
-// Striped Modifiers
-.table--even-striped {
-  tbody tr:nth-child(even) {
-    background-color: var(--_rm-table-striping-background-color);
-    color: var(--_rm-table-striping-text-color);
-  }
-}
-
-.table--odd-striped {
-  tbody tr:nth-child(odd) {
-    background-color: var(--_rm-table-striping-background-color);
-    color: var(--_rm-table-striping-text-color);
-  }
-}
-
 // Sticky Header / Footer Table Container
 .table-container {
   @extend %table-global;
@@ -143,17 +156,4 @@
   table {
     overflow: unset;
   }
-}
-
-// Sticky Header Row Modifier
-.table--sticky-header thead {
-  position: sticky;
-  top: 0;
-}
-
-// Sticky Footer Row Modifier
-.table--sticky-footer tfoot {
-  position: sticky;
-  bottom: 0;
-  background-color: var(--_rm-table-background-color);
 }

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -139,6 +139,10 @@
   @extend %table-global;
 
   overflow-y: auto;
+
+  table {
+    overflow: unset;
+  }
 }
 
 // Sticky Header Row Modifier

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -152,8 +152,4 @@
   @extend %table-global;
 
   overflow-y: auto;
-
-  table {
-    overflow: unset;
-  }
 }

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -142,13 +142,13 @@
 }
 
 // Sticky Header Row Modifier
-.table--header-sticky thead {
+.table--sticky-header thead {
   position: sticky;
   top: 0;
 }
 
 // Sticky Footer Row Modifier
-.table--footer-sticky tfoot {
+.table--sticky-footer tfoot {
   position: sticky;
   bottom: 0;
   background-color: var(--_rm-table-background-color);

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -47,7 +47,7 @@
   box-shadow: var(--_rm-table-border);
   border-radius: var(--_rm-table-border-radius);
 
-  overflow: hidden;
+  contain: paint;
 
   background-color: var(--_rm-table-background-color);
   color: var(--_rm-table-text-color);

--- a/src/components/table.scss
+++ b/src/components/table.scss
@@ -1,5 +1,4 @@
 // TODO: When we get a pagination component, add it to the table styles and docs for within a table footer
-// TODO: future improvement of sticky header or footer with scrollable rows.
 
 %table-global {
   // Public API
@@ -133,4 +132,24 @@
     background-color: var(--_rm-table-striping-background-color);
     color: var(--_rm-table-striping-text-color);
   }
+}
+
+// Sticky Header / Footer Table Container
+.table-container {
+  @extend %table-global;
+
+  overflow-y: auto;
+}
+
+// Sticky Header Row Modifier
+.table--header-sticky thead {
+  position: sticky;
+  top: 0;
+}
+
+// Sticky Footer Row Modifier
+.table--footer-sticky tfoot {
+  position: sticky;
+  bottom: 0;
+  background-color: var(--_rm-table-background-color);
 }

--- a/src/stories/Table.stories.js
+++ b/src/stories/Table.stories.js
@@ -21,6 +21,11 @@ export default {
       control: { type: 'select' },
       options: ['off', 'even', 'odd'],
     },
+    sticky: {
+      control: { type: 'select' },
+      options: ['header', 'footer', 'off'],
+    },
+    height: { control: 'boolean' },
   },
   parameters: {
     docs: {
@@ -69,4 +74,16 @@ StripedEven.args = {
 export const StripedOdd = Template.bind({});
 StripedOdd.args = {
   striped: 'odd',
+};
+
+export const StickyHeader = Template.bind({});
+StickyHeader.args = {
+  sticky: 'header',
+  height: true,
+};
+
+export const StickyFooter = Template.bind({});
+StickyFooter.args = {
+  sticky: 'footer',
+  height: true,
 };

--- a/src/stories/Table.stories.js
+++ b/src/stories/Table.stories.js
@@ -90,3 +90,9 @@ StickyFooter.args = {
   sticky: 'footer',
   height: true,
 };
+
+export const StickyBoth = Template.bind({});
+StickyBoth.args = {
+  sticky: 'both',
+  height: true,
+};

--- a/src/stories/Table.stories.js
+++ b/src/stories/Table.stories.js
@@ -23,9 +23,12 @@ export default {
     },
     sticky: {
       control: { type: 'select' },
-      options: ['header', 'footer', 'off'],
+      options: ['off', 'header', 'footer', 'both'],
     },
-    height: { control: 'boolean' },
+    height: {
+      control: 'boolean',
+      description: 'This is not a class. It just provides a fixed height to demonstrate the sticky classes'
+    },
   },
   parameters: {
     docs: {

--- a/src/stories/Table/Table.js
+++ b/src/stories/Table/Table.js
@@ -11,12 +11,16 @@ export const createTable = ({
 
   const table = document.createElement('table');
 
+  let stickyClass = ''
+  if (sticky !== 'off') { stickyClass = `table--sticky-${sticky}` }
+  if (sticky === 'both') { stickyClass = 'table--sticky-header table--sticky-footer' }
+
   table.className = [
     style === 'default' ? 'table' : `table-${style}`,
     `table--${layout}-layout`,
     `table--${density}-density`,
     striped === 'off' ? '' : `table--${striped}-striped`,
-    sticky === 'off' ? '' : `table--sticky-${sticky}`,
+    stickyClass,
   ].filter(Boolean).join(' ')
 
   table.innerHTML += `
@@ -102,6 +106,6 @@ export const createTable = ({
   } else {
 
     return table;
-  
+
   }
 };

--- a/src/stories/Table/Table.js
+++ b/src/stories/Table/Table.js
@@ -98,14 +98,10 @@ export const createTable = ({
 
   if (height) {
     tableContainer.style.height = '200px'
-
     tableContainer.appendChild(table)
 
     return tableContainer;
-
-  } else {
-
-    return table;
-
   }
+
+  return table;
 };

--- a/src/stories/Table/Table.js
+++ b/src/stories/Table/Table.js
@@ -3,7 +3,12 @@ export const createTable = ({
   layout = 'auto',
   density = 'default',
   striped = 'off',
+  sticky = 'off',
+  height = false,
 }) => {
+  const tableContainer = document.createElement('div')
+  tableContainer.className = 'table-container'
+
   const table = document.createElement('table');
 
   table.className = [
@@ -11,6 +16,7 @@ export const createTable = ({
     `table--${layout}-layout`,
     `table--${density}-density`,
     striped === 'off' ? '' : `table--${striped}-striped`,
+    sticky === 'off' ? '' : `table--sticky-${sticky}`,
   ].filter(Boolean).join(' ')
 
   table.innerHTML += `
@@ -84,7 +90,18 @@ export const createTable = ({
       <td colspan="1">11</td>
     </tr>
   </tfoot>
-`
+  `
 
-  return table;
+  if (height) {
+    tableContainer.style.height = '200px'
+
+    tableContainer.appendChild(table)
+
+    return tableContainer;
+
+  } else {
+
+    return table;
+  
+  }
 };

--- a/src/stories/Table/Table.js
+++ b/src/stories/Table/Table.js
@@ -97,7 +97,7 @@ export const createTable = ({
   `
 
   if (height) {
-    tableContainer.style.height = '200px'
+    tableContainer.style.height = '20vh'
     tableContainer.appendChild(table)
 
     return tableContainer;

--- a/src/stories/Table/Table.mdx
+++ b/src/stories/Table/Table.mdx
@@ -63,10 +63,10 @@ Table classes provide simple styling for tables and their content.
 
 `.table--sticky-header`, `.table--sticky-footer` will make either the table header or table footer sticky; the default is top/bottom of the viewport.
 
-These classes require a wrapping container with a fixed height. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div to achieve correct overflow behavior. You will also need to set a fixed height. This will allow sticky header/footer with scrollable body rows.
+These are best used in conjunction with a wrapping container fixed table height, though they will work outside of that being sticky to the browser window. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div to achieve correct overflow behavior. You will also need to set a fixed height. This will allow sticky header/footer with scrollable body rows.
 
 ```html
-<div class="table-container"> // Container div with class also needs to set the desired height; 200px in these examples
+<div class="table-container"> // Container div with class also needs to set the desired height. 200px in these examples
   <table class="table"> // Actual table element
     ...
   </table>

--- a/src/stories/Table/Table.mdx
+++ b/src/stories/Table/Table.mdx
@@ -66,7 +66,7 @@ Table classes provide simple styling for tables and their content.
 These are best used in conjunction with a wrapping container fixed table height, though they will work outside of that being sticky to the browser window. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div to achieve correct overflow behavior. You will also need to set a fixed height. This will allow sticky header/footer with scrollable body rows.
 
 ```html
-<div class="table-container"> // Container div with class also needs to set the desired height. 200px in these examples
+<div class="table-container"> // Container div with class also needs to set the desired height. 20vh in these examples
   <table class="table"> // Actual table element
     ...
   </table>

--- a/src/stories/Table/Table.mdx
+++ b/src/stories/Table/Table.mdx
@@ -59,6 +59,25 @@ Table classes provide simple styling for tables and their content.
   <Story id='components-table--striped-odd' />
 </Canvas>
 
+## Sticky Header/Footer
+
+`.table--sticky-header`, `.table--sticky-footer` will make either the table header or table footer sticky; the default is top/bottom of the viewport.
+
+These are best used in conjunction with a fixed table height. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div in order to fix the height of a table. This will allow sticky header/footer with scrollable body rows.
+
+```slim
+.table-container // Container div to set the desired height; 200px in these examples
+  table // Actual table element
+```
+
+<Canvas withToolbar>
+  <Story id='components-table--sticky-header' />
+</Canvas>
+
+<Canvas withToolbar>
+  <Story id='components-table--sticky-footer' />
+</Canvas>
+
 ## Table API
 
 The table styles are built on css variables scoped to the table.

--- a/src/stories/Table/Table.mdx
+++ b/src/stories/Table/Table.mdx
@@ -63,11 +63,14 @@ Table classes provide simple styling for tables and their content.
 
 `.table--sticky-header`, `.table--sticky-footer` will make either the table header or table footer sticky; the default is top/bottom of the viewport.
 
-These are best used in conjunction with a fixed table height. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div in order to fix the height of a table. This will allow sticky header/footer with scrollable body rows.
+These classes require a wrapping container with a fixed height. Because the actual `table` HTML element is a bit finicky, you will need to wrap the `table` itself in a `.table-container` div to achieve correct overflow behavior. You will also need to set a fixed height. This will allow sticky header/footer with scrollable body rows.
 
-```slim
-.table-container // Container div to set the desired height; 200px in these examples
-  table // Actual table element
+```html
+<div class="table-container"> // Container div with class also needs to set the desired height; 200px in these examples
+  <table class="table"> // Actual table element
+    ...
+  </table>
+</div>
 ```
 
 <Canvas withToolbar>
@@ -76,6 +79,10 @@ These are best used in conjunction with a fixed table height. Because the actual
 
 <Canvas withToolbar>
   <Story id='components-table--sticky-footer' />
+</Canvas>
+
+<Canvas withToolbar>
+  <Story id='components-table--sticky-both' />
 </Canvas>
 
 ## Table API


### PR DESCRIPTION
## Task

#82 

## What Changed

What changed in this PR?

* [X] Added styles and documentation for sticky table headers and footers, as well as a fixed height with scrolling table body

## Sanity Check

* ~~Have you updated any usage of changed tokens?~~
* [x] Have you updated the docs with any component changes?
* ~~Do you need to update the package version?~~

## Screenshots

Sticky header, fixed height:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/88258994/191128015-b86d6a83-7cd1-4289-89bf-9dc5edd9101e.png">

Sticky footer, fixed height:
<img width="977" alt="image" src="https://user-images.githubusercontent.com/88258994/191128048-f543c58b-817d-4d84-bbf8-a080d6f5ef6c.png">

