### PR TITLE
[GHI #14] Standardize Utilities

### DIFF
--- a/src/components/card.scss
+++ b/src/components/card.scss
@@ -17,6 +17,26 @@
     --rm-space-scale-unit: 0.5rem;
   }
 
+  &.card--shadow-x-small {
+    box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-x-small);
+  }
+
+  &.card--shadow-small {
+    box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-small);
+  }
+
+  &.card--shadow-medium {
+    box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-medium);
+  }
+
+  &.card--shadow-large {
+    box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-large);
+  }
+
+  &.card--shadow-x-large {
+    box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-x-large);
+  }
+
   // Elements
   .card__header,
   .card__body,

--- a/src/core/utilities.scss
+++ b/src/core/utilities.scss
@@ -167,24 +167,6 @@
   text-align: justify;
 }
 
-// Font size
-
-.font-x-small { font-size: var(--rm-font-x-small); }
-.font-small { font-size: var(--rm-font-small); }
-.font-medium { font-size: var(--rm-font-medium); }
-.font-large { font-size: var(--rm-font-large); }
-.font-x-large { font-size: var(--rm-font-x-large); }
-.font-2x-large { font-size: var(--rm-font-2x-large); }
-.font-3x-large { font-size: var(--rm-font-3x-large); }
-.font-4x-large { font-size: var(--rm-font-4x-large); }
-.font-5x-large { font-size: var(--rm-font-5x-large); }
-
-// Font Weight
-.font-light { font-weight: var(--rm-font-weight-light); }
-.font-normal { font-weight: var(--rm-font-weight-normal); }
-.font-semi-bold { font-weight: var(--rm-font-weight-semi-bold); }
-.font-bold { font-weight: var(--rm-font-weight-bold); }
-
 // Box Margin
 
 .margin-xl {

--- a/src/core/utilities.scss
+++ b/src/core/utilities.scss
@@ -365,29 +365,6 @@
   margin-left: 0;
 }
 
-// Shadows
-.shadow-x-small { box-shadow: var(--rm-shadow-x-small); }
-.shadow-small { box-shadow: var(--rm-shadow-small); }
-.shadow-medium { box-shadow: var(--rm-shadow-medium); }
-.shadow-large { box-shadow: var(--rm-shadow-large); }
-.shadow-x-large { box-shadow: var(--rm-shadow-x-large); }
-
-.shadow-x-small.card, .shadow-x-small.card-padded {
-  box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-x-small);
-}
-.shadow-small.card, .shadow-small.card-padded {
-  box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-small);
-}
-.shadow-medium.card, .shadow-medium.card-padded {
-  box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-medium);
-}
-.shadow-large.card, .shadow-large.card-padded {
-  box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-large);
-}
-.shadow-x-large.card, .shadow-x-large.card-padded {
-  box-shadow: var(--rm-border-all) var(--rm-border-color), var(--rm-shadow-x-large);
-}
-
 // Layout properties
 // Layout row evenly spaces all elements within it.
 // It also makes it responsive at the sm breakpoint.

--- a/src/stories/Card.stories.js
+++ b/src/stories/Card.stories.js
@@ -12,6 +12,10 @@ export default {
     header: { control: 'text' },
     body: { control: 'text' },
     footer: { control: 'text' },
+    shadow: {
+      control: { type: 'select' },
+      options: ['none', 'x-small', 'small', 'medium', 'large', 'x-large'],
+    },
   },
   parameters: {
     docs: {
@@ -52,4 +56,11 @@ Condensed.args = {
   header: 'Condensed',
   body: 'Body',
   footer: 'Footer',
+};
+
+export const Shadow = Template.bind({});
+Shadow.args = {
+  shadow: 'large',
+  padded: true,
+  label: 'Shadow',
 };

--- a/src/stories/Card/Card.js
+++ b/src/stories/Card/Card.js
@@ -4,7 +4,8 @@ export const createCard = ({
   label,
   header = '',
   body = '',
-  footer = ''
+  footer = '',
+  shadow = 'none',
 }) => {
   const card = document.createElement('div');
 
@@ -16,7 +17,8 @@ export const createCard = ({
 
   const coreClass = padded ? 'card-padded' : 'card';
   const condensedClass = condensed ? 'card--condensed' : '';
-  const classes = [coreClass, condensedClass].filter(Boolean).join(' ');
+  const shadowClass = shadow == 'none' ? '' : `card--shadow-${shadow}`;
+  const classes = [coreClass, condensedClass, shadowClass].filter(Boolean).join(' ');
 
   card.className = classes;
 

--- a/src/stories/Card/Card.mdx
+++ b/src/stories/Card/Card.mdx
@@ -39,6 +39,14 @@ Card classes can be used to denote bordered sections of an application. They pro
   <Story id='components-card--condensed' />
 </Canvas>
 
+## Shadow
+
+`.card--shadow-x-small`, `.card--shadow-small`, `.card--shadow-medium`, `.card--shadow-large`, `.card--shadow-x-large` Add a shadow elevation effect to the card.
+
+<Canvas withToolbar>
+  <Story id='components-card--shadow' />
+</Canvas>
+
 
 ## Overriding card styles
 

--- a/src/stories/Shadow.stories.js
+++ b/src/stories/Shadow.stories.js
@@ -1,10 +1,10 @@
-import { createShadow } from './Shadow/Shadow.js';
+import { createCard } from './Card/Card.js';
 import ShadowDocs from './Shadow/Shadow.mdx';
 
 export default {
-  title: 'Utilities/Shadow',
+  title: 'Tokens/Shadow',
   argTypes: {
-    size: {
+    shadow: {
       control: { type: 'select' },
       options: ['x-small', 'small', 'medium', 'large', 'x-large'],
     },
@@ -16,11 +16,36 @@ export default {
   },
 };
 
-const Template = ({ size, ...args }) => {
-  return createShadow({ size, ...args });
+const Template = ({ shadow, ...args }) => {
+  return createCard({ padded: true, shadow, ...args });
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  size: 'medium',
+export const XSmall = Template.bind({});
+XSmall.args = {
+  shadow: 'x-small',
+  label: 'X Small'
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  shadow: 'small',
+  label: 'Small'
+};
+
+export const Medium = Template.bind({});
+Medium.args = {
+  shadow: 'medium',
+  label: 'Medium'
+};
+
+export const Large = Template.bind({});
+Large.args = {
+  shadow: 'large',
+  label: 'Large'
+};
+
+export const XLarge = Template.bind({});
+XLarge.args = {
+  shadow: 'x-large',
+  label: 'X Large'
 };

--- a/src/stories/Shadow/Shadow.mdx
+++ b/src/stories/Shadow/Shadow.mdx
@@ -3,12 +3,29 @@ import LinkTo from '@storybook/addon-links/react';
 
 # Shadow
 
-Shadow utility classes can be used to add elevation to elements. They provide a simple box shadow style that can be composed with other box shadow variables such as <LinkTo LinkTo kind="tokens-border--default">Border</LinkTo>.
+Shadow tokens can be used to create an elevation effect on any element. There are also <LinkTo kind="components-card--shadow">Card classes</LinkTo> to create an elevated card effect.
+
+## Usage
+
+These tokens can be applied as box shadows.
+
+```css
+box-shadow: var(--rm-shadow-x-small);
+// or
+box-shadow: var(--rm-shadow-x-large);
+```
+
+## Available tokens and their definitions
+
+```css
+--rm-shadow-x-small: 0px 1px 2px hsla(0, 0%, 0%, 0.3), 0px 1px 3px hsla(0, 0%, 0%, 0.15);
+--rm-shadow-small:   0px 1px 2px hsla(0, 0%, 0%, 0.3), 0px 2px 6px hsla(0, 0%, 0%, 0.15);
+--rm-shadow-medium:  0px 4px 8px hsla(0, 0%, 0%, 0.15), 0px 1px 3px hsla(0, 0%, 0%, 0.3);
+--rm-shadow-large:   0px 6px 10px hsla(0, 0%, 0%, 0.15), 0px 2px 3px hsla(0, 0%, 0%, 0.3);
+--rm-shadow-x-large: 0px 8px 12px hsla(0, 0%, 0%, 0.15), 0px 4px 4px hsla(0, 0%, 0%, 0.3);
+```
 
 ## Playground
 
-<Canvas withToolbar>
-  <Story id='utilities-shadow--default' />
-</Canvas>
-
+<Primary/>
 <ArgsTable story='^' />


### PR DESCRIPTION
## Task

#96 

## Why?

After a team discussion, we have opted to not add utilities and instead actually remove a few.

The line we have generally drawn is that utilities should be for layout and position, not for look and feel. Therefore, the font size and weight, and shadow utilities will be deprecated. This PR moves us more in line with that goal.

## What Changed

* [X] Remove font size utilities
* [X] Remove font-weight utilities
* [X] Remove shadow utilities
* [X] Added card shadow modifiers

## Sanity Check

* [X] Have you updated any usage of changed tokens?
* [X] Have you updated the docs with any component changes?
* ~~Do you need to update the package version?~~

## Screenshots

<img width="1101" alt="Screen Shot 2022-11-14 at 6 02 42 PM" src="https://user-images.githubusercontent.com/5957102/201786160-5c1d0bf3-fd4a-409b-885f-4023fcf9374a.png">
<img width="1081" alt="Screen Shot 2022-11-14 at 6 02 49 PM" src="https://user-images.githubusercontent.com/5957102/201786164-3389706f-12bf-432b-96d7-91c5a875e6ad.png">
